### PR TITLE
Add due date support

### DIFF
--- a/backend/data/tasks.json
+++ b/backend/data/tasks.json
@@ -1,10 +1,12 @@
 [
   {
     "id": 1749061221843,
-    "text": "task1test"
+    "text": "task1test",
+    "dueDate": "2025-12-31"
   },
   {
     "id": 1749061230364,
-    "text": "task2test"
+    "text": "task2test",
+    "dueDate": "2026-01-15"
   }
 ]

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import axios from "axios";
 function App() {
   const [tasks, setTasks] = useState([]);
   const [text, setText] = useState("");
+  const [dueDate, setDueDate] = useState("");
 
   const fetchTasks = async () => {
     const res = await axios.get("http://localhost:3001/tasks");
@@ -12,8 +13,9 @@ function App() {
 
   const addTask = async () => {
     if (text.trim()) {
-      await axios.post("http://localhost:3001/tasks", { text });
+      await axios.post("http://localhost:3001/tasks", { text, dueDate });
       setText("");
+      setDueDate("");
       fetchTasks();
     }
   };
@@ -35,12 +37,18 @@ function App() {
         onChange={(e) => setText(e.target.value)}
         placeholder="Add a task"
       />
+      <input
+        type="date"
+        value={dueDate}
+        onChange={(e) => setDueDate(e.target.value)}
+      />
       <button onClick={addTask}>Add</button>
 
       <ul>
         {tasks.map((task) => (
           <li key={task.id}>
-            {task.text}{" "}
+            {task.text}
+            {task.dueDate ? ` (due ${task.dueDate})` : ""}
             <button onClick={() => deleteTask(task.id)}>❌</button>
           </li>
         ))}

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders task manager heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/Task Manager/i);
+  expect(heading).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add example due dates to existing task data
- allow setting and displaying task due dates in the React UI
- update unit test for the new heading

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414e902ad08324be82897df2715b8f