### PR TITLE
Add unit test for adding tasks

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,29 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import App from './App';
+import axios from 'axios';
+
+jest.mock('axios');
 
 test('renders task manager heading', () => {
   render(<App />);
   const heading = screen.getByText(/Task Manager/i);
   expect(heading).toBeInTheDocument();
+});
+
+test('adds a new task and displays it', async () => {
+  axios.get.mockResolvedValueOnce({ data: [] });
+  axios.post.mockResolvedValueOnce({});
+  axios.get.mockResolvedValueOnce({ data: [{ id: 1, text: 'New Task', dueDate: '' }] });
+
+  render(<App />);
+
+  const input = screen.getByPlaceholderText('Add a task');
+  fireEvent.change(input, { target: { value: 'New Task' } });
+
+  const addButton = screen.getByText('Add');
+  fireEvent.click(addButton);
+
+  await waitFor(() => {
+    expect(screen.getByText('New Task')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- mock axios in App tests
- add a test to verify a new task is displayed after clicking **Add**

## Testing
- `CI=true npm test -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841776c5b48832496e1869b44d2a1ff